### PR TITLE
Make Checkpoint Directories

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+PACE/dataset
+PACE/results
+PACE/src/__pycache__
+PACE/ckpt

--- a/PACE/src/main.py
+++ b/PACE/src/main.py
@@ -47,8 +47,18 @@ from torch.utils.data import random_split
 
 args = parser.parse_args() 
 
+#print("args", args)
 
-args.save_path = os.path.join(args.save_path, args.name)
+args.save_path = os.path.normpath(os.path.join(args.save_path, args.name)) # adjusts to windows or linux
+
+# create the directory if it doesn't exist
+if not os.path.exists(args.save_path):
+    print(f"❌ Directory does not exist: {args.save_path}")
+    os.makedirs(args.save_path, exist_ok=True) 
+    print(f"✅ Created directory: {args.save_path}")
+
+# Windows: ..\ckpt\ViT-base
+# Linux/macOS: ../ckpt/ViT-base
 
 np.random.seed(args.seed)   
 torch.manual_seed(args.seed)


### PR DESCRIPTION
Code to create `ckpt` directory if it does not already exist. This is required to run finetune ViT command: `python main.py --train  --task Color --name ViT-base --num_epochs 5 --lr 1e-3 --require_grad`

Added `ckpt`, `dataset`, `results`, and `__pycache__` directories to `.gitignore`